### PR TITLE
Minor fix in M7

### DIFF
--- a/modules/Module-07.md
+++ b/modules/Module-07.md
@@ -328,7 +328,7 @@ Let's illustrate the situation with the example of `Figure.draw(Graphics)`, from
 Here the first and last steps *should always happen in the same way*, but obviously the second step will depend on the actual concrete figure. To realize a solution, we capture the first and third steps as private methods in `AbstractFigure` (`BasicFigure` on the diagram). Assume that the code to complete these two operations can be entirely written in the superclass. The code of the `AbstractFigure` class would thus start to look like:
 
 ```java
-public AbstractFigure implements Figure
+public abstract AbstractFigure implements Figure
 {
    private void invalidate() { /* Invalidate the bounding box */ }
    private void notifyObservers() { /* Call callback on all observers */ }


### PR DESCRIPTION
Fixed abstract class definition for Template Method design pattern -- missing abstract in line 331.

Was not sure if this was intentional or not.